### PR TITLE
fix: 修复歌单tab更改时分页页码不返回第一页问题

### DIFF
--- a/src/page/playlists/index.vue
+++ b/src/page/playlists/index.vue
@@ -110,6 +110,7 @@ export default {
       scrollInto(this.$refs.playlists)
     },
     onTabChange() {
+        this.currentPage=0
       this.initData()
     }
   },

--- a/src/page/playlists/index.vue
+++ b/src/page/playlists/index.vue
@@ -110,7 +110,7 @@ export default {
       scrollInto(this.$refs.playlists)
     },
     onTabChange() {
-        this.currentPage=0
+      this.currentPage = 0
       this.initData()
     }
   },


### PR DESCRIPTION
一个小问题，不太清楚你的处理逻辑是什么，我觉得tab更改时应该回到第一页